### PR TITLE
option to require at least one worker node 

### DIFF
--- a/templates/cluster.yaml
+++ b/templates/cluster.yaml
@@ -85,6 +85,8 @@ spec:
     watchIngress: true
   kubeProxy:
     clusterCIDR: ${cluster_cidr}
+    cpuRequest: 80m
+    memoryRequest: 72Mi
   kubeControllerManager:
     horizontalPodAutoscalerSyncPeriod: 30s
     horizontalPodAutoscalerDownscaleDelay: 5m0s

--- a/variables.tf
+++ b/variables.tf
@@ -109,6 +109,12 @@ variable "max_availability_zones" {
   description = "Maximum availability zones to span with this cluster. We currently only support 3!!"
 }
 
+variable "require_one_node" {
+  type        = bool
+  default     = false
+  description = "If minSize of all worker instance group is set to 0 but at least one node is required (eg. for kube-dns)"
+}
+
 variable "max_mutating_requests_in_flight" {
   type        = number
   default     = 800


### PR DESCRIPTION
this may be useful it situations where you have all instance worker groups set to a min size of 0 an need at least one worker node to schedule tools like kube-dns etc. 