### PR TITLE
override security groups for masters and nodes

### DIFF
--- a/instance-groups.tf
+++ b/instance-groups.tf
@@ -36,9 +36,9 @@ data "null_data_source" "instance_groups" {
       storage_type           = lookup(var.instance_groups[floor(count.index / 3)], "storage_type", "gp2")
       storage_iops           = lookup(var.instance_groups[floor(count.index / 3)], "storage_iops", 0)
       storage_in_gb          = lookup(var.instance_groups[floor(count.index / 3)], "storage_in_gb", 28)
-      security_group         = lookup(var.instance_groups[floor(count.index / 3)], "security_group", "")
       subnet_type            = lookup(var.instance_groups[floor(count.index / 3)], "subnet", "private")
       subnet_ids             = [element(data.aws_availability_zones.available.names, count.index % var.max_availability_zones)]
+      security_group         = lookup(var.instance_groups[floor(count.index / 3)], "security_group", aws_security_group.nodes.id)
       autospotting_enabled   = lookup(var.instance_groups[floor(count.index / 3)], "autospotting_enabled", true)
       autospotting_max_price = lookup(var.instance_groups[floor(count.index / 3)], "autospotting_max_price", 0.03)
       autospotting_instances = lookup(var.instance_groups[floor(count.index / 3)], "autospotting_instances", [lookup(var.instance_groups[floor(count.index / 3)], "instance_type")])
@@ -76,10 +76,10 @@ data "null_data_source" "master_instance_groups" {
       public_ip              = false
       autoscaler             = false
       image                  = local.kops_default_image
+      security_group         = aws_security_group.masters.id
       external_lb_name       = coalesce(local.external_lb_name_masters, join("", aws_elb.classic_public_api.*.name), "-")
       external_target_arn    = coalesce(local.external_lb_target_arn, join("", aws_lb_target_group.api.*.arn), "-")
       instance_group_name    = element(data.null_data_source.master_info.*.outputs.name, count.index)
-      security_group         = ""
       subnet_ids             = [element(data.null_data_source.master_info.*.outputs.subnet_id, count.index)]
       subnet_type            = "private"
       storage_type           = "gp2"

--- a/kops.tf
+++ b/kops.tf
@@ -28,11 +28,11 @@ locals {
     service_cluster_ip_cidr = "100.0.0.0/16"
     pods_cluster_ip_cidr    = "100.1.0.0/16"
     ssh_access              = length(var.ssh_access_cidrs) > 0 ? var.ssh_access_cidrs : [local.vpc_cidr]
-    api_access              = length(var.api_access_cidrs) > 0 ? var.api_access_cidrs : [local.create_additional_loadbalancer ? "0.0.0.0/0" : local.vpc_cidr]
+    api_access              = length(var.api_access_cidrs) > 0 ? var.api_access_cidrs : [local.vpc_cidr]
     elb_security_group_id   = join("", aws_security_group.public_loadbalancer.*.id)
     certificate_arn         = local.certificate_arn
     lb_type                 = var.cluster_dns_type == "Private" ? "Internal" : "Public"
-    lb_create               = !local.external_lb_enabled
+    lb_create               = !local.external_lb_enabled && (!var.use_master_ips_for_private_dns || var.cluster_dns_type != "Private")
     lb_security_groups      = ""
     bastion_public_name     = var.bastion_public_name
     custom_certificate      = local.custom_certificate_enabled

--- a/security-groups.tf
+++ b/security-groups.tf
@@ -1,0 +1,83 @@
+
+module "masters_sg_label" {
+  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  context = module.label.context
+  name    = "masters"
+}
+
+module "nodes_sg_label" {
+  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  context = module.label.context
+  name    = "nodes"
+}
+
+locals {
+  additional_public_loadbalancer_sg = local.create_additional_loadbalancer ? [{
+    security_groups = aws_security_group.public_loadbalancer.*.id
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+  }] : []
+
+  security_default_rules = yamldecode(templatefile("${path.module}/templates/security-groups.yaml", {
+    nodes_sg   = aws_security_group.nodes.id
+    masters_sg = aws_security_group.masters.id
+  }))
+  
+  nodes_security_ingress   = concat(var.additional_node_ingress, local.security_default_rules.nodes)
+  masters_security_ingress = concat(var.additional_master_ingress, local.additional_public_loadbalancer_sg, local.security_default_rules.masters)
+}
+
+resource "aws_security_group" "masters" {
+  name        = module.masters_sg_label.id
+  tags        = module.masters_sg_label.tags
+  description = "Controls traffic to the master nodes of cluster ${local.cluster_name}"
+  vpc_id      = local.vpc_id
+
+  egress {
+    to_port     = 0
+    from_port   = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "masters_ingress" {
+  count             = length(local.masters_security_ingress)
+  type              = "ingress"
+  security_group_id = aws_security_group.masters.id
+  to_port           = local.masters_security_ingress[count.index].to_port
+  from_port         = local.masters_security_ingress[count.index].from_port
+  self              = lookup(local.masters_security_ingress[count.index], "self", false)
+  protocol          = lookup(local.masters_security_ingress[count.index], "protocol", "tcp")
+  cidr_blocks       = lookup(local.masters_security_ingress[count.index], "cidr_blocks", [])
+  security_groups   = lookup(local.masters_security_ingress[count.index], "security_groups", [])
+  description       = lookup(local.masters_security_ingress[count.index], "description", "Managed by Terraform")
+}
+
+resource "aws_security_group" "nodes" {
+  name        = module.nodes_sg_label.id
+  tags        = module.nodes_sg_label.tags
+  description = "Controls traffic to the worker nodes of cluster ${local.cluster_name}"
+  vpc_id      = local.vpc_id
+
+  egress {
+    to_port     = 0
+    from_port   = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "nodes_ingress" {
+  count             = length(local.nodes_security_ingress)
+  type              = "ingress"
+  security_group_id = aws_security_group.nodes.id
+  to_port           = local.nodes_security_ingress[count.index].to_port
+  from_port         = local.nodes_security_ingress[count.index].from_port
+  self              = lookup(local.nodes_security_ingress[count.index], "self", false)
+  protocol          = lookup(local.nodes_security_ingress[count.index], "protocol", "tcp")
+  cidr_blocks       = lookup(local.nodes_security_ingress[count.index], "cidr_blocks", [])
+  security_groups   = lookup(local.nodes_security_ingress[count.index], "security_groups", [])
+  description       = lookup(local.nodes_security_ingress[count.index], "description", "Managed by Terraform")
+}

--- a/templates/security-groups.yaml
+++ b/templates/security-groups.yaml
@@ -1,0 +1,55 @@
+masters:
+  - to_port: 0
+    from_port: 0
+    protocol: "-1"
+    self: true
+    # Kops security ingress rules (etcd, calico)
+  - to_port: 4001
+    from_port: 443
+    protocol: tcp
+    security_groups: 
+    - ${nodes_sg}
+  - to_port: 65535
+    from_port: 4003
+    protocol: tcp
+    security_groups: 
+    - ${nodes_sg}
+  - to_port: 65535
+    from_port: 1
+    protocol: udp
+    security_groups: 
+    - ${nodes_sg}
+  - to_port: -1
+    from_port: -1
+    protocol: ipv4
+    security_groups: 
+    - ${nodes_sg}
+nodes:
+  - to_port: 443
+    from_port: 443
+    protocol: tcp
+    security_groups:
+    - ${masters_sg}
+  # Non root ports (NodePorts, kubelet, ..)
+  - to_port: 65535
+    from_port: 3000
+    protocol: tcp
+    security_groups:
+    - ${masters_sg}
+  - to_port: 65535
+    from_port: 3000
+    protocol: tcp
+    self: true
+  - to_port: 443
+    from_port: 443
+    protocol: tcp
+    self: true
+  - to_port: 80
+    from_port: 80
+    protocol: tcp
+    self: true
+  # Calico BGP port
+  - to_port: 179
+    from_port: 179
+    protocol: tcp
+    self: true

--- a/variables.tf
+++ b/variables.tf
@@ -217,6 +217,18 @@ variable "external_master_policies" {
   description = "Additional policy ARNs to attach to the master role"
 }
 
+variable "additional_master_ingress" {
+  type        = list(object)
+  default     = []
+  description = "Additional ingress rules for security group on master nodes"  
+}
+
+variable "additional_node_ingress" {
+  type        = list(object)
+  default     = []
+  description = "Additional ingress rules for default security group for worker nodes"
+}
+
 variable "create_public_api_loadbalancer" {
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -217,6 +217,12 @@ variable "external_master_policies" {
   description = "Additional policy ARNs to attach to the master role"
 }
 
+variable "use_master_ips_for_private_dns" {
+  type        = bool
+  default     = true
+  description = "When dns type is set to private we can use private IPs available in the VPC to connect to master nodes directly"
+}
+
 variable "additional_master_ingress" {
   type        = list(object)
   default     = []


### PR DESCRIPTION
- reduced port range between masters and nodes
- ssh connections are only allowed from the bastion itself
- no need to override elb security group anymore to create public additional lb
- allow to add custom ingress rules to the security groups
- kops bastion elb security group will attach itself to the bastion sg