### PR TITLE
minimize initial cluster config

### DIFF
--- a/instance-groups.tf
+++ b/instance-groups.tf
@@ -26,7 +26,7 @@ data "null_data_source" "instance_groups" {
       node_role              = "Node"
       public_ip              = false
       autoscaler             = true
-      image                  = lookup(var.instance_groups[floor(count.index / 3)], "image", local.kops_default_image)
+      image                  = lookup(var.instance_groups[floor(count.index / 3)], "image", "")
       instance_name          = lookup(var.instance_groups[floor(count.index / 3)], "name")
       instance_type          = lookup(var.instance_groups[floor(count.index / 3)], "instance_type")
       instance_max           = lookup(var.instance_groups[floor(count.index / 3)], "count_max", 5)
@@ -35,7 +35,7 @@ data "null_data_source" "instance_groups" {
       external_target_arn    = lookup(var.instance_groups[floor(count.index / 3)], "loadbalancer_target_arn", "")
       storage_type           = lookup(var.instance_groups[floor(count.index / 3)], "storage_type", "gp2")
       storage_iops           = lookup(var.instance_groups[floor(count.index / 3)], "storage_iops", 0)
-      storage_in_gb          = lookup(var.instance_groups[floor(count.index / 3)], "storage_in_gb", 28)
+      storage_in_gb          = lookup(var.instance_groups[floor(count.index / 3)], "storage_in_gb", 32)
       security_group         = lookup(var.instance_groups[floor(count.index / 3)], "security_group", "")
       subnet_type            = lookup(var.instance_groups[floor(count.index / 3)], "subnet", "private")
       subnet_ids             = [element(data.aws_availability_zones.available.names, count.index % var.max_availability_zones)]
@@ -75,7 +75,7 @@ data "null_data_source" "master_instance_groups" {
       region                 = var.region
       public_ip              = false
       autoscaler             = false
-      image                  = local.kops_default_image
+      image                  = ""
       security_group         = aws_security_group.masters.id
       external_lb_name       = coalesce(local.external_lb_name_masters, join("", aws_elb.classic_public_api.*.name), "-")
       external_target_arn    = coalesce(local.external_lb_target_arn, join("", aws_lb_target_group.api.*.arn), "-")
@@ -84,7 +84,7 @@ data "null_data_source" "master_instance_groups" {
       subnet_type            = "private"
       storage_type           = "gp2"
       storage_iops           = 0
-      storage_in_gb          = 32
+      storage_in_gb          = 48
       node_role              = "Master"
       instance_name          = "master"
       instance_max           = 1
@@ -106,7 +106,7 @@ data "null_data_source" "bastion_instance_group" {
       namespace              = var.namespace
       stage                  = var.stage
       region                 = var.region
-      image                  = local.kops_default_image
+      image                  = ""
       external_lb_name       = ""
       autoscaler             = false
       storage_type           = "gp2"

--- a/kops.tf
+++ b/kops.tf
@@ -15,7 +15,7 @@ locals {
     dns_type                = var.cluster_dns_type
     k8s_version             = var.kubernetes_version
     etcd_version            = var.etcd_version
-    cluster_cidr            = "100.0.0.0/16"
+    cluster_cidr            = "100.64.0.0/10"
     namespace               = var.namespace
     stage                   = var.stage
     region                  = var.region
@@ -53,7 +53,6 @@ locals {
     additional_master_policies = var.additional_master_policies == "" ? "" : indent(6, replace(var.additional_master_policies, "/\\\"/", "\\\""))
   })
 
-  kops_default_image = "kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17"
   kops_configs = concat(
     [data.null_data_source.bastion_instance_group.outputs],
     data.null_data_source.master_instance_groups.*.outputs,

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -20,7 +20,7 @@ module "api_loadbalancer_label" {
 
 resource "aws_security_group" "public_loadbalancer" {
   count       = local.create_additional_loadbalancer ? 1 : 0
-  name        = module.api_loadbalancer_label.id
+  name        = "public-api.${local.cluster_dns}"
   tags        = module.api_loadbalancer_label.tags
   description = "Allows public HTTPS inbound traffic to API Server"
   vpc_id      = local.vpc_id

--- a/security-groups.tf
+++ b/security-groups.tf
@@ -3,11 +3,10 @@ module "masters_sg_label" {
   source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
   context   = module.label.context
   name      = "masters"
-  delimiter = "."
 }
 
 resource "aws_security_group" "masters" {
-  name        = module.masters_sg_label.id
+  name        = "masters.${local.cluster_dns}"
   tags        = module.masters_sg_label.tags
   description = "Controls traffic to the master nodes of cluster ${local.cluster_name}"
   vpc_id      = local.vpc_id

--- a/templates/cluster.yaml
+++ b/templates/cluster.yaml
@@ -84,6 +84,7 @@ spec:
     Namespace: ${namespace}
     Stage: ${stage}
     Region: ${region}
+    kops.k8s.io/cluster: ${cluster_dns}
   etcdClusters:
   - etcdMembers:
 %{ for index, member in etcd_members ~}

--- a/templates/cluster.yaml
+++ b/templates/cluster.yaml
@@ -2,6 +2,8 @@ apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   name: ${cluster_dns}
+  labels:
+    kops.k8s.io/cluster: ${cluster_dns}
 spec:
   cloudProvider: aws
   kubernetesVersion: ${k8s_version}

--- a/templates/cluster.yaml
+++ b/templates/cluster.yaml
@@ -36,7 +36,6 @@ spec:
   networking:
     calico:
       majorVersion: v3
-      crossSubnet: true
 %{ if additional_master_policies != "" ~}
   additionalPolicies:
     master: |
@@ -60,12 +59,10 @@ spec:
     dns: {}
 %{ endif ~}
   kubeAPIServer:
-    targetRamMb: 2560
     # Kops generates a kubecfg with http basic credentials
     disableBasicAuth: false
     maxRequestsInflight: ${max_requests_in_flight}
     maxMutatingRequestsInflight: ${max_mutating_requests_in_flight}
-    serviceNodePortRange: 20000-65000
   kubelet:
     anonymousAuth: false
   docker:

--- a/templates/cluster.yaml
+++ b/templates/cluster.yaml
@@ -2,8 +2,6 @@ apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   name: ${cluster_dns}
-  labels:
-    kops.k8s.io/cluster: ${cluster_dns}
 spec:
   cloudProvider: aws
   kubernetesVersion: ${k8s_version}
@@ -61,7 +59,6 @@ spec:
 %{ endif ~}
   kubeAPIServer:
     targetRamMb: 2560
-    eventTTL: 12h0m0s
     # Kops generates a kubecfg with http basic credentials
     disableBasicAuth: false
     maxRequestsInflight: ${max_requests_in_flight}
@@ -69,17 +66,6 @@ spec:
     serviceNodePortRange: 20000-65000
   kubelet:
     anonymousAuth: false
-    kubeReserved:
-      cpu: 70m
-      memory: 128Mi
-      ephemeral-storage: 1Gi
-    systemReserved:
-      cpu: 30m
-      memory: 112Mi
-      ephemeral-storage: 1Gi
-    kubeReservedCgroup: "/kube-reserved"
-    systemReservedCgroup: "/system-reserved"
-    enforceNodeAllocatable: "pods,system-reserved,kube-reserved"
   docker:
     logDriver: json-file
     logOpt:
@@ -90,23 +76,12 @@ spec:
   kubeProxy:
     cpuRequest: 80m
     memoryRequest: 128Mi
-  kubeControllerManager:
-    horizontalPodAutoscalerSyncPeriod: 30s
-    horizontalPodAutoscalerDownscaleDelay: 5m0s
-    horizontalPodAutoscalerUpscaleDelay: 3m0s
-    horizontalPodAutoscalerTolerance: 0.1
-  authorization:
-    rbac: {}
-  iam:
-    allowContainerRegistry: true
-    legacy: false
   channel: stable
   cloudLabels:
     Cluster: ${cluster_name}
     Namespace: ${namespace}
     Stage: ${stage}
     Region: ${region}
-    kops.k8s.io/cluster: ${cluster_dns}
   etcdClusters:
   - etcdMembers:
 %{ for index, member in etcd_members ~}
@@ -135,8 +110,8 @@ spec:
 %{ endfor ~}
     name: events
     version: ${etcd_version}
-    cpuRequest: 200m
-    memoryRequest: 624Mi
+    cpuRequest: 120m
+    memoryRequest: 156Mi
     enableEtcdTLS: true
   subnets:
 %{ for index, id in public_subnet_ids ~}

--- a/templates/cluster.yaml
+++ b/templates/cluster.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   cloudProvider: aws
   kubernetesVersion: ${k8s_version}
-  masterPublicName: api.${cluster_dns}
-  masterInternalName: api.${cluster_dns}
+  masterPublicName: ${cluster_dns}
+  masterInternalName: ${cluster_dns}
   networkID: ${vpc_id}
   networkCIDR: ${vpc_cidr}
   awsRegion: ${aws_region}
@@ -52,15 +52,12 @@ spec:
 %{ if lb_create ~}
     loadBalancer:
       type: ${lb_type}
-      crossZoneLoadBalancing: true
       sslCertificate: ${certificate_arn}
       additionalSecurityGroups: [${lb_security_groups}]
 %{ else ~}
     dns: {}
 %{ endif ~}
   kubeAPIServer:
-    # Kops generates a kubecfg with http basic credentials
-    disableBasicAuth: false
     maxRequestsInflight: ${max_requests_in_flight}
     maxMutatingRequestsInflight: ${max_mutating_requests_in_flight}
   kubelet:
@@ -70,8 +67,6 @@ spec:
     logOpt:
     - max-size=32m
     - max-file=12
-  externalDns:
-    watchIngress: true
   kubeProxy:
     cpuRequest: 80m
     memoryRequest: 128Mi

--- a/templates/instance-group.yaml
+++ b/templates/instance-group.yaml
@@ -12,6 +12,7 @@ spec:
     Stage: ${stage}
     Region: ${region}
     Role: ${instance_name}
+    InstanceType: ${instance_name}
     InstanceGroup: ${instance_group_name}
     kubernetes.io/cluster/${cluster_dns}: owned
 %{ if autoscaler ~}

--- a/templates/instance-group.yaml
+++ b/templates/instance-group.yaml
@@ -60,6 +60,8 @@ spec:
     Role: ${instance_name}
     InstanceGroup: ${instance_group_name}
     InstanceType: ${instance_name}
+    kops.k8s.io/cluster: ${cluster_dns}
+    kops.k8s.io/instancegroup: ${instance_group_name}
 %{ if autospotting_enabled ~}
     spot: \"true\"
 %{ endif ~}

--- a/templates/instance-group.yaml
+++ b/templates/instance-group.yaml
@@ -2,6 +2,9 @@ apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   name: ${instance_group_name}
+  labels:
+    kops.k8s.io/cluster: ${cluster_dns}
+    kops.k8s.io/instancegroup: ${instance_group_name}
 spec:
   cloudLabels:
     Cluster: ${cluster_name}

--- a/templates/instance-group.yaml
+++ b/templates/instance-group.yaml
@@ -2,9 +2,6 @@ apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   name: ${instance_group_name}
-  labels:
-    kops.k8s.io/cluster: ${cluster_dns}
-    kops.k8s.io/instancegroup: ${instance_group_name}
 spec:
   cloudLabels:
     Cluster: ${cluster_name}
@@ -12,15 +9,16 @@ spec:
     Stage: ${stage}
     Region: ${region}
     Role: ${instance_name}
-    kops.k8s.io/cluster: ${cluster_dns}
-    kops.k8s.io/instancegroup: ${instance_group_name}
+    InstanceGroup: ${instance_group_name}
     kubernetes.io/cluster/${cluster_dns}: owned
 %{ if autoscaler ~}
     k8s.io/cluster-autoscaler/enabled: \"\"
-    k8s.io/cluster-autoscaler/node-template/label/instance_type: ${instance_name}
-    k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup: ${instance_group_name}
+    k8s.io/cluster-autoscaler/node-template/label/InstanceType: ${instance_name}
+    k8s.io/cluster-autoscaler/node-template/label/InstanceGroup: ${instance_group_name}
 %{ endif ~}
+%{ if image != "" ~}
   image: ${image}
+%{ endif ~}
   machineType: ${instance_type}
   maxSize: ${instance_max}
   minSize: ${instance_min}
@@ -31,27 +29,6 @@ spec:
 %{ if security_group != "" ~}
   securityGroupOverride: ${security_group}
 %{ endif ~}
-  additionalUserData:
-  - name: reserved-resources.sh
-    type: text/x-shellscript
-    content: |-
-      #!/bin/sh
-      sudo mkdir -p /sys/fs/cgroup/cpu,cpuacct/system-reserved;
-      sudo mkdir -p /sys/fs/cgroup/cpuset/system-reserved;
-      sudo mkdir -p /sys/fs/cgroup/cpu/system-reserved;
-      sudo mkdir -p /sys/fs/cgroup/memory/system-reserved;
-      sudo mkdir -p /sys/fs/cgroup/blkio/system-reserved;
-      sudo mkdir -p /sys/fs/cgroup/pids/system-reserved;
-      sudo mkdir -p /sys/fs/cgroup/devices/system-reserved;
-      sudo mkdir -p /sys/fs/cgroup/systemd/system-reserved;
-      sudo mkdir -p /sys/fs/cgroup/cpu,cpuacct/kube-reserved;
-      sudo mkdir -p /sys/fs/cgroup/cpuset/kube-reserved;
-      sudo mkdir -p /sys/fs/cgroup/cpu/kube-reserved;
-      sudo mkdir -p /sys/fs/cgroup/memory/kube-reserved;
-      sudo mkdir -p /sys/fs/cgroup/blkio/kube-reserved;
-      sudo mkdir -p /sys/fs/cgroup/pids/kube-reserved;
-      sudo mkdir -p /sys/fs/cgroup/devices/kube-reserved;
-      sudo mkdir -p /sys/fs/cgroup/systemd/kube-reserved;
 %{ if external_lb_name != "-" || external_target_arn != "-" ~}
   externalLoadBalancers:
   %{ if external_lb_name != "-" }
@@ -78,9 +55,8 @@ spec:
     Stage: ${stage}
     Region: ${region}
     Role: ${instance_name}
-    kops.k8s.io/cluster: ${cluster_dns}
-    kops.k8s.io/instancegroup: ${instance_group_name}
-    instance_type: ${instance_name}
+    InstanceGroup: ${instance_group_name}
+    InstanceType: ${instance_name}
 %{ if autospotting_enabled ~}
     spot: \"true\"
 %{ endif ~}

--- a/variables.tf
+++ b/variables.tf
@@ -243,7 +243,7 @@ variable "public_api_loadbalancer_type" {
 
 variable "public_api_record_name" {
   type        = string
-  default     = "api"
+  default     = ""
   description = "Name of the publicly available additional public dns record"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "masters_instance_count" {
 
 variable "etcd_version" {
   type        = string
-  default     = "3.3.13"
+  default     = "3.2.24"
   description = "Version of etcd to use for kubernetes backend"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -34,7 +34,7 @@ variable "region" {
 
 variable "kubernetes_version" {
   type        = string
-  default     = "1.15.10"
+  default     = "1.16.8"
   description = "The kubernetes version to deploy" 
 }
 


### PR DESCRIPTION
Some pods remain currently in `ContainerCreating` state because CNI cannot reach K8S API. There seems to be a configuration problem. These changes fix the current issues. Its not fully clear yet which changes affected the network timeouts. 

Possibly:
- cgroup config  
- network cidr changes
- cross subnet balancing for API and calico  
- service node port range