### PR TITLE
do not specify ssl certificate for private hosted zone

### DIFF
--- a/templates/cluster.yaml
+++ b/templates/cluster.yaml
@@ -54,8 +54,10 @@ spec:
 %{ if lb_create ~}
     loadBalancer:
       type: ${lb_type}
-      sslCertificate: ${certificate_arn}
       additionalSecurityGroups: [${lb_security_groups}]
+%{ if certificate_arn != "" ~}
+      sslCertificate: ${certificate_arn}
+%{ endif ~}
 %{ else ~}
     dns: {}
 %{ endif ~}


### PR DESCRIPTION
relates to https://github.com/kubernetes/kops/blob/298f79659a2bd9c1d6548c6c95b335b5e29e6466/pkg/kubeconfig/create_kubecfg.go\#L90

currently when the dns record switches between internal elb and master ips
this causes some nodes (usually newly upcoming nodes) to fail on certificate validation

when creating an additional, public load balancer we can use the internal elb to simply proxy traffic on 443
there is no need to have the load balancer validating & changing the CA