### PR TITLE
3allow to configure additional public dns record

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,13 +251,15 @@ A simple setup for a publicly available kops cluster without using any remote st
 
 ```hcl
 module "kops" {
-  source             = "git::https://github.com/goci-io/aws-kops-cluster.git?ref=tags/<latest-version>"
-  cluster_dns        = "corp.eu1.goci.io"
-  cluster_dns_type   = "Public"
-  vpc_id             = "vpc-12345678"
-  public_subnet_ids  = ["subnet-abc"]
-  private_subnet_ids = ["subnet-cba"]
-  instance_groups  = [
+  source               = "git::https://github.com/goci-io/aws-kops-cluster.git?ref=tags/<latest-version>"
+  cluster_dns          = "corp.eu1.goci.io"
+  cluster_dns_type     = "Public"
+  vpc_id               = "vpc-12345678"
+  public_subnet_ids    = ["subnet-abc"]
+  public_subnet_cidrs  = ["10.0.0.0/24"]
+  private_subnet_ids   = ["10.0.1.0/24"]
+  private_subnet_cidrs = 
+  instance_groups      = [
     {
       name          = "worker"
       instance_type = "t2.medium"

--- a/README.md
+++ b/README.md
@@ -219,6 +219,31 @@ You can still create public Ingress resources to route traffic using a different
 
 **Note:** You can also pass vpc and subnet details into the module without using remote state references. The above example assumes you habe a vpc with remote state already installed. Kops can also generate a VPC for you. This scenario is currently not covered. Let us know if you run into any issues!
 
+#### Private Cluster with public API only
+
+You might want to setup a cluster in your VPC but allow traffic to the API server from the outside world. Be careful when exposing your API server to the public world! 
+When choosing this setup you get a dedicated load balancer for public facing traffic and one, created by kops, managing internal/cluster traffic. If you dont need or have a **Private and Public Hosted Zone* available you can consider using `cluster_dns_type` with `Public` to avoid a separate Load Balancer and Hosted zone. But we recommend the following setup:
+```hcl
+module "kops" {
+  source                          = ""
+  namespace                       = "goci"
+  stage                           = "staging"
+  cluster_dns_type                = "Private"
+  tf_bucket                       = "my-terraform-state-bucket"
+  vpc_module_state                = "vpc/terraform.tfstate"
+  create_public_api_loadbalancer  = true
+  enable_classic_api_loadbalancer = false|true
+  public_api_record_name          = "api"
+  instance_groups = [
+    {
+      name                   = "worker"
+      instance_type          = "t2.medium"
+    }
+  ]
+}
+```
+To avoid setting up an additional Load Balancer for the internal/cluster communication you can also set `use_master_ips_for_private_dns` to true. This way kops does not know about your ACM certificate if you use one and you need to make sure to add the ACM CA to your kubernetes API configuration. When masters come up successfully they currently sync IP addresses with the record in your private zone anyway. Enforcing this setup can be done by enabling the above mentioned feature. 
+
 #### Kops validation
 
 By default when spinning up the cluster the first time the script [`scripts/wait-for-cluster.sh`] is executed and runs `kops validate cluster`, awaiting a healthy cluster state. Keep in mind once you spin up a cluster we will need to wait for: EC2 instances, Route53 records and the API server and required tools becoming ready and healthy. This may take a while. If you anyway need to disable the initial validation you can set `enable_kops_validation` to `false`. When updating the cluster we assume other machanisms in place when the cluster is put in a bad state after a rollout. Most changes are only rolled out once a new EC2 node comes up. You can also force the update by using `kops rolling-update cluster`. We might offer in the feature to combine the `kops update` with a rolling update if required, but usually this is something requiring some kind of approval/review process before updating.

--- a/instance-groups.tf
+++ b/instance-groups.tf
@@ -77,9 +77,9 @@ data "null_data_source" "master_instance_groups" {
       public_ip              = false
       autoscaler             = false
       image                  = ""
-      security_group         = ""
-      external_lb_name       = local.external_lb_name_masters
-      external_target_arn    = local.external_lb_target_arn
+      security_group         = aws_security_group.masters.id
+      external_lb_name       = join("", aws_elb.public_api.*.name)
+      external_target_arn    = ""
       instance_group_name    = element(data.null_data_source.master_info.*.outputs.name, count.index)
       subnet_ids             = [element(data.null_data_source.master_info.*.outputs.subnet_id, count.index)]
       subnet_type            = "private"

--- a/kops.tf
+++ b/kops.tf
@@ -86,7 +86,6 @@ module "ssh_key_pair" {
 resource "null_resource" "replace_cluster" {
   depends_on = [
     null_resource.wait_for_iam,
-
     aws_s3_bucket_public_access_block.block,
   ]
 
@@ -133,7 +132,10 @@ EOF
 
 resource "null_resource" "cluster_startup" {
   count      = var.enable_kops_validation ? 1 : 0
-  depends_on = [null_resource.kops_update_cluster]
+  depends_on = [
+    module.public_api_record.fqdn,
+    null_resource.kops_update_cluster,
+  ]
 
   provisioner "local-exec" {
     # This is only required during the initial setup

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -1,0 +1,55 @@
+locals {
+  api_log_prefix = "api/logs/${local.cluster_dns}"
+}
+
+module "api_loadbalancer_label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  context    = module.label.context
+  attributes = ["api"]
+}
+
+resource "aws_elb" "public_api" {
+  count                       = var.create_public_api_record ? 1 : 0
+  name                        = module.api_loadbalancer_label.id
+  tags                        = module.api_loadbalancer_label.tags
+  subnets                     = local.public_subnet_ids
+  security_groups             = aws_security_group.public_loadbalancer.*.id
+  connection_draining         = true
+  cross_zone_load_balancing   = true
+  internal                    = false
+  idle_timeout                = 900
+
+  listener {
+    lb_port            = 443
+    lb_protocol        = "SSL"
+    instance_port      = 443
+    instance_protocol  = "SSL"
+    ssl_certificate_id = local.certificate_arn
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    target              = "SSL:443"
+    interval            = 30
+  }
+
+  access_logs {
+    bucket        = aws_s3_bucket.kops_state.id
+    bucket_prefix = "${local.api_log_prefix}/public"
+    enabled       = true
+  }
+}
+
+module "public_api_record" {
+  source      = "git::https://github.com/goci-io/aws-route53-records.git?ref=tags/0.2.1"
+  enabled     = var.create_public_api_record
+  hosted_zone = local.cluster_dns
+  records     = [
+    {
+      alias      = join("", aws_elb.public_api.*.dns_name)
+      alias_zone = join("", aws_elb.public_api.*.zone_id)
+    }
+  ]
+}

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -48,6 +48,7 @@ module "public_api_record" {
   hosted_zone = local.cluster_dns
   records     = [
     {
+      name       = var.public_record_name
       alias      = join("", aws_elb.public_api.*.dns_name)
       alias_zone = join("", aws_elb.public_api.*.zone_id)
     }

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -43,7 +43,7 @@ resource "aws_elb" "public_api" {
 }
 
 module "public_api_record" {
-  source      = "git::https://github.com/goci-io/aws-route53-records.git?ref=tags/0.2.1"
+  source      = "git::https://github.com/goci-io/aws-route53-records.git?ref=master"
   enabled     = var.create_public_api_record
   hosted_zone = local.cluster_dns
   records     = [

--- a/main.tf
+++ b/main.tf
@@ -7,10 +7,16 @@ data "aws_availability_zones" "available" {
 
 locals {
   attributes     = concat(var.attributes, [var.region])
-  tags           = merge(var.tags, map("Cluster", local.cluster_name))
+  tags           = merge(var.tags, map("KubernetesCluster", local.cluster_name))
   cluster_name   = format("%s.%s.%s", var.stage, var.region, var.namespace)
   aws_region     = var.aws_region == "" ? data.aws_region.current.name : var.aws_region
   aws_account_id = var.aws_account_id == "" ? data.aws_caller_identity.current.account_id : var.aws_account_id
+}
+
+data "aws_route53_zone" "cluster_zone" {
+  count        = local.cluster_dns == "" ? 0 : 1
+  name         = format("%s.", local.cluster_dns)
+  private_zone = var.cluster_dns_type == "Private"
 }
 
 module "label" {

--- a/remote.tf
+++ b/remote.tf
@@ -29,33 +29,6 @@ data "terraform_remote_state" "dns" {
   }
 }
 
-data "terraform_remote_state" "loadbalancer" {
-  count   = var.loadbalancer_module_state == "" ? 0 : 1
-  backend = "s3"
-
-  config = {
-    bucket = var.tf_bucket
-    key    = var.loadbalancer_module_state
-  }
-}
-/*
-data "terraform_remote_state" "custom_cert" {
-  count   = local.custom_certificate_enabled ? 1 : 0
-  backend = "s3"
-
-  config = {
-    bucket = var.tf_bucket
-    key    = var.api_cert_module_state
-  }
-}
-*/
-
-data "aws_route53_zone" "cluster_zone" {
-  count        = local.cluster_dns == "" ? 0 : 1
-  name         = format("%s.", local.cluster_dns)
-  private_zone = var.cluster_dns_type == "Private"
-}
-
 locals {
   acm_module_state = var.acm_module_state == "" && var.dns_module_state != "" && var.certificate_arn == "" ? var.dns_module_state : var.acm_module_state
 
@@ -69,12 +42,4 @@ locals {
   private_subnet_ids   = length(var.private_subnet_ids) > 0 ? var.private_subnet_ids : data.terraform_remote_state.vpc[0].outputs.private_subnet_ids
   public_subnet_cidrs  = length(var.public_subnet_cidrs) > 0 ? var.public_subnet_cidrs : data.terraform_remote_state.vpc[0].outputs.public_subnet_cidrs
   private_subnet_cidrs = length(var.private_subnet_cidrs) > 0 ? var.private_subnet_cidrs : data.terraform_remote_state.vpc[0].outputs.private_subnet_cidrs
-
-  external_lb_enabled      = local.external_lb_target_arn != "" || local.external_lb_name_masters != ""
-  external_lb_name_masters = var.master_loadbalancer_name == "" && length(data.terraform_remote_state.loadbalancer) > 0 ? lookup(data.terraform_remote_state.loadbalancer[0].outputs, "loadbalancer_name", "") : var.master_loadbalancer_name
-  external_lb_target_arn   = var.master_loadbalancer_target_arn == "" && length(data.terraform_remote_state.loadbalancer) > 0 ? lookup(data.terraform_remote_state.loadbalancer[0].outputs, "loadbalancer_target_arn", "") : var.master_loadbalancer_target_arn
-
-  #custom_certificate_enabled  = var.api_cert_module_state != ""
-  #certificate_ca_pem          = join("", data.terraform_remote_state.custom_cert.*.outputs.certificate_ca_cert)
-  #certificate_ca_key_pem      = join("", data.terraform_remote_state.custom_cert.*.outputs.certificate_ca_key)
 }

--- a/s3.tf
+++ b/s3.tf
@@ -11,6 +11,17 @@ locals {
     "arn:aws:s3:::${aws_s3_bucket.kops_state.id}/${local.cluster_dns}/*",
   ]
 
+  lb_access_log_account = {
+    eu-central-1 = "054676820928",
+    eu-west-2 = "652711504416",
+    us-east-1 = "127311923021",
+    us-west-2 = "797873946194",
+    ap-northeast-2 = "600734575887",
+    ap-southeast-1 = "114774131450",
+    ap-east-1 = "754344448648",
+    # TODO: complete list
+  }
+
   api_log_s3_policies = [
     {
       readonly  = false
@@ -21,7 +32,28 @@ locals {
         identifiers = ["delivery.logs.amazonaws.com"]
       }]
     },
+    {
+      readonly  = false
+      resources = [format("%s/%s/*", aws_s3_bucket.kops_state.arn, local.api_log_prefix)]
+      actions   = ["s3:PutObject"]
+      principals = [{
+        type        = "Service"
+        identifiers = ["delivery.logs.amazonaws.com"]
+      }]
+    },
+    {
+      readonly  = false
+      resources = [format("%s/%s/*", aws_s3_bucket.kops_state.arn, local.api_log_prefix)]
+      actions   = ["s3:PutObject"]
+      principals = [{
+        type        = "AWS"
+        identifiers = [format("arn:aws:iam::%s:root", local.lb_access_log_account[local.aws_region])]
+      }]
+    }
   ]
+
+  required_s3_policies = concat([], var.create_public_api_record ? local.api_log_s3_policies : [])
+  custom_s3_policies   = concat(var.custom_s3_policies, local.required_s3_policies)
 }
 
 resource "aws_s3_bucket" "kops_state" {
@@ -51,13 +83,22 @@ resource "aws_s3_bucket" "kops_state" {
       days = 90
     }
   }
+
+  lifecycle_rule {
+    enabled = var.create_public_api_record
+    prefix  = local.api_log_prefix
+
+    expiration {
+      days = 120
+    }
+  }
 }
 
 data "aws_iam_policy_document" "custom_s3" {
-  count = length(var.custom_s3_policies) > 0 ? 1 : 0
+  count = length(local.custom_s3_policies) > 0 ? 1 : 0
 
   dynamic "statement" {
-    for_each = var.custom_s3_policies
+    for_each = local.custom_s3_policies
 
     content {
       effect    = "Allow"
@@ -77,7 +118,7 @@ data "aws_iam_policy_document" "custom_s3" {
 }
 
 resource "aws_s3_bucket_policy" "current" {
-  count  = length(var.custom_s3_policies) > 0 ? 1 : 0
+  count  = length(local.custom_s3_policies) > 0 ? 1 : 0
   bucket = aws_s3_bucket.kops_state.id
   policy = join("", data.aws_iam_policy_document.custom_s3.*.json)
 }

--- a/security-groups.tf
+++ b/security-groups.tf
@@ -1,0 +1,56 @@
+module "masters_sg_label" {
+  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  context   = module.label.context
+  name      = "masters"
+}
+
+resource "aws_security_group" "masters" {
+  name        = "masters.${local.cluster_dns}"
+  tags        = module.masters_sg_label.tags
+  description = "Controls traffic to the master nodes of cluster ${local.cluster_name}"
+  vpc_id      = local.vpc_id
+
+  egress {
+    to_port     = 0
+    from_port   = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "masters_ingress" {
+  count                    = var.create_public_api_record ? 1 : 0
+  source_security_group_id = join("", aws_security_group.public_loadbalancer.*.id)
+  security_group_id        = aws_security_group.masters.id
+  type                     = "ingress"
+  to_port                  = 443
+  from_port                = 443
+  protocol                 = "tcp"
+  description              = "Allows access from a public API Load Balancer security group"
+}
+
+resource "aws_security_group" "public_loadbalancer" {
+  count       = var.create_public_api_record ? 1 : 0
+  name        = "public-api.${local.cluster_dns}"
+  tags        = module.api_loadbalancer_label.tags
+  description = "Allows public HTTPS inbound traffic to API Server"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/templates/cluster.yaml
+++ b/templates/cluster.yaml
@@ -51,15 +51,10 @@ spec:
 %{ endfor ~}
 %{ endif ~}
   api:
-%{ if lb_create ~}
     loadBalancer:
       type: ${lb_type}
 %{ if certificate_arn != "" ~}
       sslCertificate: "${certificate_arn}"
-%{ endif ~}
-      additionalSecurityGroups: [${lb_security_groups}]
-%{ else ~}
-    dns: {}
 %{ endif ~}
   kubeAPIServer:
     maxRequestsInflight: ${max_requests_in_flight}
@@ -91,7 +86,6 @@ spec:
     memoryRequest: 128Mi
   channel: stable
   cloudLabels:
-    Cluster: ${cluster_name}
     Namespace: ${namespace}
     Stage: ${stage}
     Region: ${region}

--- a/templates/instance-group.yaml
+++ b/templates/instance-group.yaml
@@ -7,13 +7,12 @@ metadata:
     kops.k8s.io/instancegroup: ${instance_group_name}
 spec:
   cloudLabels:
-    Cluster: ${cluster_name}
     Namespace: ${namespace}
     Stage: ${stage}
     Region: ${region}
-    Role: ${instance_name}
     InstanceType: ${instance_name}
     InstanceGroup: ${instance_group_name}
+    kops.k8s.io/cluster: ${cluster_dns}
     kubernetes.io/cluster/${cluster_dns}: owned
 %{ if autoscaler ~}
     k8s.io/cluster-autoscaler/enabled: \"\"
@@ -54,13 +53,11 @@ spec:
   %{ endfor ~}
 %{ endif }
   nodeLabels:
-    Cluster: ${cluster_name}
     Namespace: ${namespace}
     Stage: ${stage}
     Region: ${region}
-    Role: ${instance_name}
-    InstanceGroup: ${instance_group_name}
     InstanceType: ${instance_name}
+    InstanceGroup: ${instance_group_name}
     kops.k8s.io/cluster: ${cluster_dns}
     kops.k8s.io/instancegroup: ${instance_group_name}
 %{ if autospotting_enabled ~}

--- a/variables.tf
+++ b/variables.tf
@@ -183,10 +183,10 @@ variable "create_public_api_record" {
   description = "Creates a public API record and grants 0.0.0.0/0 on the API LB security group. This is useful in scenarios where you want to use private dns but make the API server accessible using a public hosted zone"
 }
 
-variable "master_ips_for_private_dns" {
-  type        = bool
-  default     = true
-  description = "If set to false will use the internal load balancer created by kops for internal master name. Otherwise masters will sync their IP addresses"
+variable "public_record_name" {
+  type        = string
+  default     = ""
+  description = "Subdomain to use for the additional public record pointing to the master API"
 }
 
 variable "cluster_dns" {

--- a/variables.tf
+++ b/variables.tf
@@ -177,6 +177,18 @@ variable "api_access_cidrs" {
   description = "Allowed CIDRs to acces kubernetes master API"
 }
 
+variable "create_public_api_record" {
+  type        = bool
+  default     = false
+  description = "Creates a public API record and grants 0.0.0.0/0 on the API LB security group. This is useful in scenarios where you want to use private dns but make the API server accessible using a public hosted zone"
+}
+
+variable "master_ips_for_private_dns" {
+  type        = bool
+  default     = true
+  description = "If set to false will use the internal load balancer created by kops for internal master name. Otherwise masters will sync their IP addresses"
+}
+
 variable "cluster_dns" {
   type        = string
   default     = ""
@@ -193,24 +205,6 @@ variable "tf_bucket" {
   type        = string
   default     = ""
   description = "The Bucket name to load remote state from"
-}
-
-variable "loadbalancer_module_state" {
-  type        = string
-  default     = ""
-  description = "The key or path to the state where a LoadBalancer was installed. It must expose a loadbalancer_name OR loadbalancer_target_arn"
-}
-
-variable "master_loadbalancer_name" {
-  type        = string
-  default     = ""
-  description = "The name of an existing load balancer to use for the kubernetes API if loadbalancer_module_state is not set"
-}
-
-variable "master_loadbalancer_target_arn" {
-  type        = string
-  default     = ""
-  description = "The ARN of an existing target group to use for the kubernetes API if loadbalancer_module_state is not set"
 }
 
 variable "additional_master_policies" {


### PR DESCRIPTION
this is useful when using private dns for the cluster but the API needs to be accessible to CI systems or world open